### PR TITLE
Bugfix for going fullscreen for a live stream

### DIFF
--- a/lib/src/player/youtube_player.dart
+++ b/lib/src/player/youtube_player.dart
@@ -232,7 +232,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
       } else {
         controller.pause();
         var _cachedPosition = controller.value.position;
-        var _videoId = controller.metadata.videoId;
+        var _videoId = (controller.metadata.videoId != '')?controller.metadata.videoId:controller.initialVideoId;
         _cachedWebController = controller.value.webViewController;
         controller.reset();
 


### PR DESCRIPTION
The value of _videoId is not set, so should revert to initialVideoId.